### PR TITLE
Snippets and other smaller related improvements

### DIFF
--- a/src/ExplorerController.jsx
+++ b/src/ExplorerController.jsx
@@ -389,7 +389,6 @@ export class ExplorerController extends React.Component {
             <div className="selected placeholder">
               <h4>Datasets Selected: { this.props.selectedDistributions.size }</h4>
               <a href="#" className="help-link"><FontAwesomeIcon icon={faQuestionCircle} /> How Do I Use This Selection?</a>
-              {/* <a href="#" className="btn btn-primary float-right">View Snippets </a> */}
               <Link to="/snippets" params={{ selectedDistributions: this.state.selectedDistributions }} className="btn btn-primary float-right">View Snippets </Link>
               <ul className="selected-datasets">
                 {

--- a/src/ExplorerController.jsx
+++ b/src/ExplorerController.jsx
@@ -406,7 +406,7 @@ export class ExplorerController extends React.Component {
                     { this.renderPageButtons() }
                   </div>
                 </header>
-                <ResultsList data={this.state.results} license={this.state.license} addDistToSelection={this.addDistToSelection} />
+                <ResultsList data={this.state.results} license={this.state.license} addDistToSelection={this.addDistToSelection} deleteDistFromSelection={this.deleteDistFromSelection} selectedDistributions={this.props.selectedDistributions} />
 
                 <footer>
                   <div className="pagination">

--- a/src/ExplorerController.jsx
+++ b/src/ExplorerController.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-// import PropTypes from 'prop-types';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import {
   Row, Col, Button, Label, Form, Input, FormGroup,
@@ -14,12 +14,14 @@ import { faSearch } from '@fortawesome/free-solid-svg-icons/faSearch';
 import { faTimes } from '@fortawesome/free-solid-svg-icons/faTimes';
 import { faQuestionCircle } from '@fortawesome/free-solid-svg-icons/faQuestionCircle';
 import { SearchFacet, ResultsList } from './explorer';
-import { getUser, getAuthenticated } from './reducers';
+import { getUser, getAuthenticated, getSelectedDatasets } from './reducers';
+import * as snippetActions from "./snippets/actions";
 
 function mapStateToProps(state) {
   return {
     user: getUser(state),
     isAuthenticated: getAuthenticated(state),
+    selectedDatasets: getSelectedDatasets(state),
   };
 }
 
@@ -69,17 +71,13 @@ const restrictedPubs = [
 ];
 
 export class ExplorerController extends React.Component {
-  static updateDatasetCache(datasets) {
-    // let oldItems = localStorage.getItem('selectedDatasets')
-    // console.log(oldItems)
-    // localStorage.setItem('selectedDatasets', oldItems +','+  JSON.stringify(datasets))
-    localStorage.setItem('selectedDatasets', JSON.stringify(datasets));
-    // console.log(localStorage.getItem('selectedDatasets'))
+  static propTypes = {
+    selectedDatasets: PropTypes.instanceOf(Map),
+    dispatch: PropTypes.func.isRequired,
   }
 
-  static propTypes = {
-    // user: PropTypes.objectOf(PropTypes.any).isRequired,
-    // isAuthenticated: PropTypes.bool.isRequired,
+  static defaultProps = {
+    selectedDatasets: Map(),
   }
 
   constructor(props) {
@@ -106,7 +104,6 @@ export class ExplorerController extends React.Component {
     search: {
       keywords: '',
     },
-    selectedDatasets: new Map(JSON.parse(localStorage.getItem('selectedDatasets'))),
     query: {
       aggs: {
         formats: {
@@ -196,19 +193,11 @@ export class ExplorerController extends React.Component {
   }
 
   addDatasetToSelect = (dataset) => {
-    this.setState((prevState) => {
-      const temp = prevState.selectedDatasets.set(dataset._id, dataset);
-      ExplorerController.updateDatasetCache(temp);
-      return { selectedDatasets: temp };
-    });
+    this.props.dispatch(snippetActions.selectionAddDataset(dataset));
   }
 
   delDatasetFromSelect = (id) => {
-    this.setState((prevState) => {
-      const temp = prevState.selectedDatasets.delete(id);
-      ExplorerController.updateDatasetCache(temp);
-      return { selectedDatasets: temp };
-    });
+    this.props.dispatch(snippetActions.selectionDeleteDataset(id));
   }
 
   searchHandler = (event) => {
@@ -397,7 +386,7 @@ export class ExplorerController extends React.Component {
               <Link to="/snippets" params={{ selectedDatasets: this.state.selectedDatasets }} className="btn btn-primary float-right">View Snippets </Link>
               <ul className="selected-datasets">
                 {
-                  [...this.state.selectedDatasets.values()].map((record, index) => (
+                  [...this.props.selectedDatasets.values()].map((record, index) => (
                     <li key={record._id}><a className="selected-dataset"> { record._source.title } <FontAwesomeIcon onClick={() => this.delDatasetFromSelect(record._id)} icon={faTimes} /></a></li>
                   ))
                 }

--- a/src/ExplorerController.jsx
+++ b/src/ExplorerController.jsx
@@ -14,14 +14,14 @@ import { faSearch } from '@fortawesome/free-solid-svg-icons/faSearch';
 import { faTimes } from '@fortawesome/free-solid-svg-icons/faTimes';
 import { faQuestionCircle } from '@fortawesome/free-solid-svg-icons/faQuestionCircle';
 import { SearchFacet, ResultsList } from './explorer';
-import { getUser, getAuthenticated, getSelectedDatasets } from './reducers';
+import { getUser, getAuthenticated, getSelectedDistributions } from './reducers';
 import * as snippetActions from "./snippets/actions";
 
 function mapStateToProps(state) {
   return {
     user: getUser(state),
     isAuthenticated: getAuthenticated(state),
-    selectedDatasets: getSelectedDatasets(state),
+    selectedDistributions: getSelectedDistributions(state),
   };
 }
 
@@ -72,12 +72,12 @@ const restrictedPubs = [
 
 export class ExplorerController extends React.Component {
   static propTypes = {
-    selectedDatasets: PropTypes.instanceOf(Map),
+    selectedDistributions: PropTypes.instanceOf(Map),
     dispatch: PropTypes.func.isRequired,
   }
 
   static defaultProps = {
-    selectedDatasets: Map(),
+    selectedDistributions: Map(),
   }
 
   constructor(props) {
@@ -192,12 +192,19 @@ export class ExplorerController extends React.Component {
       });
   }
 
-  addDatasetToSelect = (dataset) => {
-    this.props.dispatch(snippetActions.selectionAddDataset(dataset));
+  /**
+   * Adds a given distribution to the selection set for snippets
+   */
+  addDistToSelection = (dataset) => {
+    this.props.dispatch(snippetActions.selectionAddDistribution(dataset));
   }
 
-  delDatasetFromSelect = (id) => {
-    this.props.dispatch(snippetActions.selectionDeleteDataset(id));
+  /**
+   * Deletes the distribution with the given ID from the selection set for
+   * snippets
+   */
+  deleteDistFromSelection = (id) => {
+    this.props.dispatch(snippetActions.selectionDeleteDistribution(id));
   }
 
   searchHandler = (event) => {
@@ -380,14 +387,14 @@ export class ExplorerController extends React.Component {
           </Col>
           <Col lg="9" md="12">
             <div className="selected placeholder">
-              <h4>Datasets Selected: 1</h4>
+              <h4>Datasets Selected: { this.props.selectedDistributions.size }</h4>
               <a href="#" className="help-link"><FontAwesomeIcon icon={faQuestionCircle} /> How Do I Use This Selection?</a>
               {/* <a href="#" className="btn btn-primary float-right">View Snippets </a> */}
-              <Link to="/snippets" params={{ selectedDatasets: this.state.selectedDatasets }} className="btn btn-primary float-right">View Snippets </Link>
+              <Link to="/snippets" params={{ selectedDistributions: this.state.selectedDistributions }} className="btn btn-primary float-right">View Snippets </Link>
               <ul className="selected-datasets">
                 {
-                  [...this.props.selectedDatasets.values()].map((record, index) => (
-                    <li key={record._id}><a className="selected-dataset"> { record._source.title } <FontAwesomeIcon onClick={() => this.delDatasetFromSelect(record._id)} icon={faTimes} /></a></li>
+                  [...this.props.selectedDistributions.values()].map(dist => (
+                    <li key={dist.identifier}><a className="selected-dataset"> { dist.title } <FontAwesomeIcon onClick={() => this.deleteDistFromSelection(dist.identifier)} icon={faTimes} /></a></li>
                   ))
                 }
               </ul>
@@ -400,7 +407,7 @@ export class ExplorerController extends React.Component {
                     { this.renderPageButtons() }
                   </div>
                 </header>
-                <ResultsList data={this.state.results} license={this.state.license} addDatasetToSelect={this.addDatasetToSelect} />
+                <ResultsList data={this.state.results} license={this.state.license} addDistToSelection={this.addDistToSelection} />
 
                 <footer>
                   <div className="pagination">

--- a/src/SnippetsController.jsx
+++ b/src/SnippetsController.jsx
@@ -192,7 +192,7 @@ export class SnippetsController extends React.Component {
                     return (
                       <li key={distId}>
                         <a className="selected-dataset" href="#" onClick={() => this.toggleCollapseDistribution(distId)}>
-                          <FontAwesomeIcon icon={faChevronRight} /> &nbsp;
+                          <FontAwesomeIcon className="arrow-icon" icon={faChevronRight} /> &nbsp;
                           {dist.title}
                         </a>
                       </li>
@@ -202,7 +202,7 @@ export class SnippetsController extends React.Component {
                   return (
                     <li key={distId}>
                       <a className="selected-dataset" href="#" onClick={() => this.toggleCollapseDistribution(distId)}>
-                        <FontAwesomeIcon icon={faChevronDown} /> &nbsp;
+                        <FontAwesomeIcon className="arrow-icon" icon={faChevronDown} /> &nbsp;
                         {dist.title}
                       </a>
                       <div className="float-right">

--- a/src/SnippetsController.jsx
+++ b/src/SnippetsController.jsx
@@ -11,11 +11,11 @@ import {
   faArrowCircleLeft, faCaretDown, faServer, faChevronDown, faChevronRight,
   faCopy, faDownload, faCloudUploadAlt,
 } from '@fortawesome/free-solid-svg-icons';
-import { getSelectedDatasets } from './reducers';
+import { getSelectedDistributions } from './reducers';
 
 function mapStateToProps(state) {
   return {
-    selectedDatasets: getSelectedDatasets(state),
+    selectedDatasets: getSelectedDistributions(state),
   };
 }
 

--- a/src/SnippetsController.jsx
+++ b/src/SnippetsController.jsx
@@ -206,8 +206,8 @@ export class SnippetsController extends React.Component {
                         {dist.title}
                       </a>
                       <div className="float-right">
-                        <a className="btn btn-primary btn-sm"> Store in Drive &nbsp; <FontAwesomeIcon icon={faCloudUploadAlt} /> </a> &nbsp;
-                        <a className="btn btn-primary btn-sm"> Download <FontAwesomeIcon icon={faDownload} /></a>
+                        { /* <a className="btn btn-primary btn-sm"> Store in Drive &nbsp; <FontAwesomeIcon icon={faCloudUploadAlt} /> </a> &nbsp; */ }
+                        <a className="btn btn-primary btn-sm" href={url} target="_blank" rel="noopener noreferrer"> Download file <FontAwesomeIcon icon={faDownload} /></a>
                       </div>
 
                       <div className="snippet-body">

--- a/src/SnippetsController.jsx
+++ b/src/SnippetsController.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-// import PropTypes from 'prop-types';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import {
   Row, Col,
@@ -11,12 +11,11 @@ import {
   faArrowCircleLeft, faCaretDown, faServer, faChevronDown, faChevronRight,
   faCopy, faDownload, faCloudUploadAlt,
 } from '@fortawesome/free-solid-svg-icons';
-import { getUser, getAuthenticated } from './reducers';
+import { getSelectedDatasets } from './reducers';
 
 function mapStateToProps(state) {
   return {
-    user: getUser(state),
-    isAuthenticated: getAuthenticated(state),
+    selectedDatasets: getSelectedDatasets(state),
   };
 }
 
@@ -28,26 +27,19 @@ function mapDispatchToProps(dispatch) {
 
 export class SnippetsController extends React.Component {
   static propTypes = {
-    // user: PropTypes.objectOf(PropTypes.any).isRequired,
-    // isAuthenticated: PropTypes.bool.isRequired,
+    selectedDatasets: PropTypes.instanceOf(Map),
+  }
+
+  static defaultProps = {
+    selectedDatasets: Map(),
   }
 
   constructor(props) {
     super(props);
     this.state = {
       collapsedDataset: new Map(),
-      selectedDatasets: new Map(),
       snippetLanguages: ['Python', 'R', 'Bash', 'Web Access'],
     };
-  }
-
-  componentWillMount() {
-    // console.log(this.props)
-  }
-
-  componentDidMount() {
-    const tempSelectDatasets = JSON.parse(localStorage.getItem('selectedDatasets'));
-    this.setState({ selectedDatasets: new Map(tempSelectDatasets) });
   }
 
   collapseDataset(id) {
@@ -85,7 +77,7 @@ export class SnippetsController extends React.Component {
           <Col xs="12">
             <ul className="selected-datasets">
               {
-                [...this.state.selectedDatasets.values()].map((record) => {
+                [...this.props.selectedDatasets.values()].map((record) => {
                   const distributionUrls = record._source.distributions.map(dist => (dist.downloadURL ? dist.downloadURL : ''));
                   // console.log(distributionUrls)
                   if (this.state.collapsedDataset.get(record._id)) {
@@ -106,8 +98,8 @@ export class SnippetsController extends React.Component {
                             <p className="source">Provider: <a href={record._source.landingPage}> {record._source.landingPage} </a></p>
                           </div>
                           {
-                            this.state.snippetLanguages.map((language, index) => (
-                              <div key={index}>
+                            this.state.snippetLanguages.map(language => (
+                              <div key={language}>
                                 <div>
                                   {language}
                                   <a href="#" className="float-right source"> Copy to Clipboard <FontAwesomeIcon icon={faCopy} /></a>

--- a/src/SnippetsController.jsx
+++ b/src/SnippetsController.jsx
@@ -35,7 +35,7 @@ function generateSnippetText(language, url) {
   switch (language) {
     case 'Python':
       return `import urllib.request
-url = '${url}'
+url = '${url.replace(/'/g, '\\\'')}'
 data = urllib.request.urlopen(url).read().decode('utf-8')`;
 
     case 'R':

--- a/src/SnippetsController.jsx
+++ b/src/SnippetsController.jsx
@@ -12,6 +12,7 @@ import {
   faCopy, faDownload, faCloudUploadAlt,
 } from '@fortawesome/free-solid-svg-icons';
 import { getSelectedDistributions } from './reducers';
+import SnippetItem from "./snippets/SnippetItem";
 
 function mapStateToProps(state) {
   return {
@@ -23,98 +24,6 @@ function mapDispatchToProps(dispatch) {
   return {
     dispatch,
   };
-}
-
-/**
- * Generates code snippet text for a given data URL
- *
- * @param {string} language Target language to generate snippet for
- * @param {string} url URL of source data for snippet
- */
-function generateSnippetText(language, url) {
-  switch (language) {
-    case 'Python':
-      return `import urllib.request
-url = '${url.replace(/'/g, '\\\'')}'
-data = urllib.request.urlopen(url).read().decode('utf-8')`;
-
-    case 'R':
-      // TODO: Generate download code
-      return `url <- "${url}"
-# TODO: Download code`;
-
-    case 'Bash':
-      return `curl -O ${url}`;
-
-    case 'Web Access':
-      return url;
-
-    default:
-      throw new Error(`Language "${language}" not supported`);
-  }
-}
-
-/**
- * Selects all text within target element
- *
- * @param {Element} element Target element to select text within
- */
-function selectElementText(element) {
-  // Go over the selection range
-  const range = document.createRange();
-  range.selectNodeContents(element);
-
-  // Apply selection to the window
-  const selection = window.getSelection();
-  selection.removeAllRanges();
-  selection.addRange(range);
-
-  return selection;
-}
-
-/**
- * Generates Promise around handler for copying text to the clipboard
- *
- * @param {string} text Text to copy to clipboard (not guaranteed; see
- *        `copyTextToClipboard()`)
- *
- * @returns {Promise}
- */
-function generateClipboardCopyPromise(text) {
-  // Detect whether we can use the latest Clipboard API methods
-  if (navigator.clipboard && navigator.clipboard.writeText) {
-    return navigator.clipboard.writeText(text);
-  }
-
-  // Use old `execCommand` based API
-  // NOTE: Requires active selection in the window
-  return new Promise((resolve, reject) => {
-    const success = document.execCommand('copy');
-    if (success) {
-      resolve();
-    } else {
-      reject();
-    }
-  });
-}
-
-/**
- * Copies text to clipboard
- *
- * Note that this will attempt to first use the Clipboard API with given text,
- * otherwise will fire a copy event which will only copy the last selected
- * text within the document.
- *
- * @param {string} text Text to copy to clipboard (not guaranteed; see notes)
- */
-function copyTextToClipboard(text) {
-  const textCopyPromise = generateClipboardCopyPromise(text);
-
-  return textCopyPromise
-    .catch(() => {
-      // Alert when copy failed
-      alert('Text was not copied; please copy manually');
-    });
 }
 
 export class SnippetsController extends React.Component {
@@ -129,8 +38,7 @@ export class SnippetsController extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      collapsedDataset: new Set(),
-      snippetLanguages: ['Python', 'R', 'Bash', 'Web Access'],
+      collapsedDataset: Set(),
     };
   }
 
@@ -176,71 +84,9 @@ export class SnippetsController extends React.Component {
           <Col xs="12">
             <ul className="selected-datasets">
               {
-                [...this.props.selectedDistributions.values()].map((dist) => {
-                  /**
-                   * URL of the distribution
-                   *
-                   * @type {string | undefined}
-                   */
-                  const url = dist.downloadURL;
-                  const distId = dist.identifier;
-
-                  const isCollapsed = this.state.collapsedDataset.has(distId);
-
-                  // If collapsed, render only the collapsed portion
-                  if (isCollapsed) {
-                    return (
-                      <li key={distId}>
-                        <a className="selected-dataset" href="#" onClick={() => this.toggleCollapseDistribution(distId)}>
-                          <FontAwesomeIcon className="arrow-icon" icon={faChevronRight} /> &nbsp;
-                          {dist.title}
-                        </a>
-                      </li>
-                    );
-                  }
-
-                  return (
-                    <li key={distId}>
-                      <a className="selected-dataset" href="#" onClick={() => this.toggleCollapseDistribution(distId)}>
-                        <FontAwesomeIcon className="arrow-icon" icon={faChevronDown} /> &nbsp;
-                        {dist.title}
-                      </a>
-                      <div className="float-right">
-                        { /* <a className="btn btn-primary btn-sm"> Store in Drive &nbsp; <FontAwesomeIcon icon={faCloudUploadAlt} /> </a> &nbsp; */ }
-                        <a className="btn btn-primary btn-sm" href={url} target="_blank" rel="noopener noreferrer"> Download file <FontAwesomeIcon icon={faDownload} /></a>
-                      </div>
-
-                      <div className="snippet-body">
-                        <div>
-                          <p>{dist.description}</p>
-                        </div>
-                        {
-                          this.state.snippetLanguages.map((language) => {
-                            // Creating a reference so that the actual <code>
-                            // element may be referred to for copying text
-                            const snippetTextElementRef = React.createRef();
-
-                            const snippetText = generateSnippetText(language, url);
-
-                            return (
-                              <div key={language}>
-                                <div>
-                                  {language}
-                                  <a href="#" className="float-right source" onClick={() => { selectElementText(snippetTextElementRef.current); copyTextToClipboard(snippetText); }}> Copy to Clipboard <FontAwesomeIcon icon={faCopy} /></a>
-                                </div>
-
-                                <div>
-                                  <code ref={snippetTextElementRef}>{snippetText}</code>
-                                </div>
-
-                              </div>
-                            );
-                          })
-                        }
-                      </div>
-                    </li>
-                  );
-                })
+                this.props.selectedDistributions.valueSeq().map(dist => (
+                  <SnippetItem key={dist.identifier} distribution={dist} collapsed={this.state.collapsedDataset.has(dist.identifier)} toggleCollapsed={id => this.toggleCollapseDistribution(id)} />
+                ))
               }
             </ul>
           </Col>

--- a/src/SnippetsController.jsx
+++ b/src/SnippetsController.jsx
@@ -33,20 +33,20 @@ function mapDispatchToProps(dispatch) {
  */
 function generateSnippetText(language, url) {
   switch (language) {
-    case "Python":
+    case 'Python':
       return `import urllib.request
 url = '${url}'
 data = urllib.request.urlopen(url).read().decode('utf-8')`;
 
-    case "R":
+    case 'R':
       // TODO: Generate download code
       return `url <- "${url}"
 # TODO: Download code`;
 
-    case "Bash":
+    case 'Bash':
       return `curl -O ${url}`;
 
-    case "Web Access":
+    case 'Web Access':
       return url;
 
     default:
@@ -77,6 +77,8 @@ function selectElementText(element) {
  *
  * @param {string} text Text to copy to clipboard (not guaranteed; see
  *        `copyTextToClipboard()`)
+ *
+ * @returns {Promise}
  */
 function generateClipboardCopyPromise(text) {
   // Detect whether we can use the latest Clipboard API methods
@@ -87,7 +89,7 @@ function generateClipboardCopyPromise(text) {
   // Use old `execCommand` based API
   // NOTE: Requires active selection in the window
   return new Promise((resolve, reject) => {
-    const success = document.execCommand("copy");
+    const success = document.execCommand('copy');
     if (success) {
       resolve();
     } else {
@@ -111,7 +113,7 @@ function copyTextToClipboard(text) {
   return textCopyPromise
     .catch(() => {
       // Alert when copy failed
-      alert("Text was not copied; please copy manually");
+      alert('Text was not copied; please copy manually');
     });
 }
 

--- a/src/assets/scss/default.scss
+++ b/src/assets/scss/default.scss
@@ -727,7 +727,7 @@ section#main {
 					padding: 1em 0;
 					border-bottom: $grey-box-border solid 1px;
 					.arrow-icon {
-						width: 1em;
+						width: 1rem;
 					}
 					.selected-dataset {
 						text-decoration: none;

--- a/src/assets/scss/default.scss
+++ b/src/assets/scss/default.scss
@@ -688,6 +688,8 @@ section#main {
 				}
 				.distributions {
 					line-height: 1.5rem;
+					padding: 0;
+					list-style: none;
 					.format {
 						background:$dull-header;
 						color:white;

--- a/src/assets/scss/default.scss
+++ b/src/assets/scss/default.scss
@@ -733,11 +733,15 @@ section#main {
 					.snippet-body{
 						font-size: 16px;
 						padding-left: 28px;
-						pre{
+						code{
+							display: block;
 							background-color: #EFEFEF;
 							padding: 15px;
+							margin: 0.5em 0;
 							font-size: 12px;
 							color: $light-gray;
+							overflow: auto;
+							white-space: pre;
 						}
 					}
 				}

--- a/src/assets/scss/default.scss
+++ b/src/assets/scss/default.scss
@@ -724,8 +724,11 @@ section#main {
 				padding-left: 0px;
 				list-style: none;
 				li {	
-					padding-top: 20px;
+					padding: 1em 0;
 					border-bottom: $grey-box-border solid 1px;
+					.arrow-icon {
+						width: 1em;
+					}
 					.selected-dataset {
 						text-decoration: none;
 						font-size: 24px;

--- a/src/explorer/ResultsList.jsx
+++ b/src/explorer/ResultsList.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
-  Button, Row, Col, Alert, UncontrolledTooltip,
+  Row, Col, Alert, UncontrolledTooltip,
 } from 'reactstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faExternalLinkSquareAlt } from '@fortawesome/free-solid-svg-icons/faExternalLinkSquareAlt';
@@ -69,7 +69,7 @@ class ResultsList extends React.Component {
             return (
               <li key={dist.identifier}>
                 <input type="checkbox" checked={this.props.selectedDistributions.has(dist.identifier)} onChange={e => this.handleCheckboxChange(dist, e.target.checked)} />
-                {" "}<a href={url}>{dist.title}</a>{" "}
+                {' '}<a href={url}>{dist.title}</a>{' '}
                 <small className="licence-header"> Format </small>
                 <small className="format">{dist.format}</small>
                 <i className="licence-hover" id={`dist-${ridx}-${didx}`}> <small className="licence-header">  Licence </small>

--- a/src/explorer/ResultsList.jsx
+++ b/src/explorer/ResultsList.jsx
@@ -13,6 +13,8 @@ class ResultsList extends React.Component {
     data: PropTypes.arrayOf(PropTypes.any).isRequired,
     license: PropTypes.objectOf(PropTypes.any),
     addDistToSelection: PropTypes.func.isRequired,
+    deleteDistFromSelection: PropTypes.func.isRequired,
+    selectedDistributions: PropTypes.objectOf(PropTypes.any).isRequired,
   }
 
   static defaultProps = {
@@ -34,6 +36,26 @@ class ResultsList extends React.Component {
     return longName;
   }
 
+  /**
+   * Handler for adding/removing distributions through checkboxes
+   *
+   * @param {object} dist Distribution object
+   * @param {boolean} checked Whether the distribution has been checked to be
+   *        added to the selection list
+   */
+  handleCheckboxChange(dist, checked) {
+    // TODO: Component needs to be split so the distribution ID doesn't need to
+    // be provided to the handler and instead should be read from the
+    // subcomponent's props
+
+    // If checked, add to selection, otherwise remove
+    if (checked === true) {
+      this.props.addDistToSelection(dist);
+    } else {
+      this.props.deleteDistFromSelection(dist.identifier);
+    }
+  }
+
   renderResults() {
     const { data } = this.props;
 
@@ -45,7 +67,9 @@ class ResultsList extends React.Component {
           dists = r.distributions.map((dist, didx) => {
             const url = dist.downloadURL || dist.accessURL;
             return (
-              <li key={dist.identifier}><a href={url}>{dist.title}</a>
+              <li key={dist.identifier}>
+                <input type="checkbox" checked={this.props.selectedDistributions.has(dist.identifier)} onChange={e => this.handleCheckboxChange(dist, e.target.checked)} />
+                <a href={url}> {dist.title} </a>
                 <small className="licence-header"> Format </small>
                 <small className="format">{dist.format}</small>
                 <i className="licence-hover" id={`dist-${ridx}-${didx}`}> <small className="licence-header">  Licence </small>
@@ -54,7 +78,6 @@ class ResultsList extends React.Component {
                 <UncontrolledTooltip placement="top" target={`dist-${ridx}-${didx}`}>
                   {dist.license ? dist.license.name : 'None'}
                 </UncontrolledTooltip>
-                <Button className="btn-sm" onClick={() => this.props.addDistToSelection(dist)}>Add To Selection</Button>
               </li>
             );
           });

--- a/src/explorer/ResultsList.jsx
+++ b/src/explorer/ResultsList.jsx
@@ -69,7 +69,7 @@ class ResultsList extends React.Component {
             return (
               <li key={dist.identifier}>
                 <input type="checkbox" checked={this.props.selectedDistributions.has(dist.identifier)} onChange={e => this.handleCheckboxChange(dist, e.target.checked)} />
-                <a href={url}> {dist.title} </a>
+                {" "}<a href={url}>{dist.title}</a>{" "}
                 <small className="licence-header"> Format </small>
                 <small className="format">{dist.format}</small>
                 <i className="licence-hover" id={`dist-${ridx}-${didx}`}> <small className="licence-header">  Licence </small>

--- a/src/explorer/ResultsList.jsx
+++ b/src/explorer/ResultsList.jsx
@@ -12,7 +12,7 @@ class ResultsList extends React.Component {
   static propTypes = {
     data: PropTypes.arrayOf(PropTypes.any).isRequired,
     license: PropTypes.objectOf(PropTypes.any),
-    addDatasetToSelect: PropTypes.func.isRequired,
+    addDistToSelection: PropTypes.func.isRequired,
   }
 
   static defaultProps = {
@@ -54,6 +54,7 @@ class ResultsList extends React.Component {
                 <UncontrolledTooltip placement="top" target={`dist-${ridx}-${didx}`}>
                   {dist.license ? dist.license.name : 'None'}
                 </UncontrolledTooltip>
+                <Button className="btn-sm" onClick={() => this.props.addDistToSelection(dist)}>Add To Selection</Button>
               </li>
             );
           });
@@ -114,7 +115,6 @@ class ResultsList extends React.Component {
                   r.landingPage && r.landingPage.length > 0
                   && <a className="btn btn-primary btn-sm" href={r.landingPage}>Go to website <FontAwesomeIcon icon={faExternalLinkSquareAlt} /></a>
                 }
-                <Button className="btn-sm" onClick={() => this.props.addDatasetToSelect(record)}>Add To Selection</Button>
               </Col>
             </Row>
           </div>

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -1,6 +1,7 @@
 import * as actions from './actions';
 import projectsReducer, * as projects from './projects/reducers';
 import computeReducer, * as compute from './compute/reducers';
+import snippetsReducer, * as snippets from './snippets/reducers';
 
 
 function userReducer(state = { idTokenParsed: {}, authenticated: false }, action) {
@@ -29,6 +30,7 @@ const rootReducers = {
   auth: userReducer,
   projects: projectsReducer,
   compute: computeReducer,
+  snippets: snippetsReducer,
 };
 
 export default rootReducers;
@@ -58,3 +60,5 @@ export const getUser = state => state.auth && state.auth.idTokenParsed;
 export const getAuthenticated = state => state.auth && state.auth.authenticated;
 
 export const getServers = state => compute.getServers(state.compute);
+
+export const getSelectedDatasets = state => snippets.getSelectedDatasets(state.snippets);

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -61,4 +61,4 @@ export const getAuthenticated = state => state.auth && state.auth.authenticated;
 
 export const getServers = state => compute.getServers(state.compute);
 
-export const getSelectedDatasets = state => snippets.getSelectedDatasets(state.snippets);
+export const getSelectedDistributions = state => snippets.getSelectedDistributions(state.snippets);

--- a/src/snippets/SnippetItem.jsx
+++ b/src/snippets/SnippetItem.jsx
@@ -24,9 +24,9 @@ url = '${url.replace(/'/g, '\\\'')}'
 data = urllib.request.urlopen(url).read().decode('utf-8')`;
 
     case 'R':
-      // TODO: Generate download code
-      return `url <- "${url}"
-# TODO: Download code`;
+      return `library(RCurl)
+url <- "${url.replace(/"/g, '\\"')}"
+data <- getURLContent(url)`;
 
     case 'Bash':
       return `curl -O ${url}`;

--- a/src/snippets/SnippetItem.jsx
+++ b/src/snippets/SnippetItem.jsx
@@ -1,0 +1,181 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import {
+  faChevronDown, faChevronRight, faCopy, faDownload,
+} from '@fortawesome/free-solid-svg-icons';
+
+/**
+ * Array of supported languages for snippets
+ */
+const snippetLanguages = ['Python', 'R', 'Bash', 'Web Access'];
+
+/**
+ * Generates code snippet text for a given data URL
+ *
+ * @param {string} language Target language to generate snippet for
+ * @param {string} url URL of source data for snippet
+ */
+function generateSnippetText(language, url) {
+  switch (language) {
+    case 'Python':
+      return `import urllib.request
+url = '${url.replace(/'/g, '\\\'')}'
+data = urllib.request.urlopen(url).read().decode('utf-8')`;
+
+    case 'R':
+      // TODO: Generate download code
+      return `url <- "${url}"
+# TODO: Download code`;
+
+    case 'Bash':
+      return `curl -O ${url}`;
+
+    case 'Web Access':
+      return url;
+
+    default:
+      throw new Error(`Language "${language}" not supported`);
+  }
+}
+
+/**
+ * Selects all text within target element
+ *
+ * @param {Element} element Target element to select text within
+ */
+function selectElementText(element) {
+  // Go over the selection range
+  const range = document.createRange();
+  range.selectNodeContents(element);
+
+  // Apply selection to the window
+  const selection = window.getSelection();
+  selection.removeAllRanges();
+  selection.addRange(range);
+
+  return selection;
+}
+
+/**
+ * Generates Promise around handler for copying text to the clipboard
+ *
+ * @param {string} text Text to copy to clipboard (not guaranteed; see
+ *        `copyTextToClipboard()`)
+ *
+ * @returns {Promise}
+ */
+function generateClipboardCopyPromise(text) {
+  // Detect whether we can use the latest Clipboard API methods
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    return navigator.clipboard.writeText(text);
+  }
+
+  // Use old `execCommand` based API
+  // NOTE: Requires active selection in the window
+  return new Promise((resolve, reject) => {
+    const success = document.execCommand('copy');
+    if (success) {
+      resolve();
+    } else {
+      reject();
+    }
+  });
+}
+
+/**
+ * Copies text to clipboard
+ *
+ * Note that this will attempt to first use the Clipboard API with given text,
+ * otherwise will fire a copy event which will only copy the last selected
+ * text within the document.
+ *
+ * @param {string} text Text to copy to clipboard (not guaranteed; see notes)
+ */
+function copyTextToClipboard(text) {
+  const textCopyPromise = generateClipboardCopyPromise(text);
+
+  return textCopyPromise
+    .catch(() => {
+      // Alert when copy failed
+      alert('Text was not copied; please copy manually');
+    });
+}
+
+export class SnippetItem extends React.Component {
+  static propTypes = {
+    distribution: PropTypes.objectOf(PropTypes.any).isRequired,
+    collapsed: PropTypes.bool,
+    toggleCollapsed: PropTypes.func.isRequired,
+  }
+
+  static defaultProps = {
+    collapsed: false,
+  }
+
+  render() {
+    const dist = this.props.distribution;
+
+    /** @type {string | undefined} */
+    const url = dist.downloadURL;
+    /** @type {string} */
+    const distId = dist.identifier;
+    /** @type {boolean} */
+    const isCollapsed = this.props.collapsed;
+
+    // If collapsed, render only the collapsed portion
+    if (isCollapsed) {
+      return (
+        <li key={distId}>
+          <a className="selected-dataset" href="#" onClick={() => this.props.toggleCollapsed(distId)}>
+            <FontAwesomeIcon className="arrow-icon" icon={faChevronRight} /> &nbsp;
+            {dist.title}
+          </a>
+        </li>
+      );
+    }
+
+    return (
+      <li key={distId}>
+        <a className="selected-dataset" href="#" onClick={() => this.props.toggleCollapsed(distId)}>
+          <FontAwesomeIcon className="arrow-icon" icon={faChevronDown} /> &nbsp;
+          {dist.title}
+        </a>
+        <div className="float-right">
+          { /* <a className="btn btn-primary btn-sm"> Store in Drive &nbsp; <FontAwesomeIcon icon={faCloudUploadAlt} /> </a> &nbsp; */ }
+          <a className="btn btn-primary btn-sm" href={url} target="_blank" rel="noopener noreferrer"> Download file <FontAwesomeIcon icon={faDownload} /></a>
+        </div>
+
+        <div className="snippet-body">
+          <div>
+            <p>{dist.description}</p>
+          </div>
+          {
+            snippetLanguages.map((language) => {
+              // Creating a reference so that the actual <code> element may be
+              // referred to for copying text
+              const snippetTextElementRef = React.createRef();
+
+              const snippetText = generateSnippetText(language, url);
+
+              return (
+                <div key={language}>
+                  <div>
+                    {language}
+                    <a href="#" className="float-right source" onClick={() => { selectElementText(snippetTextElementRef.current); copyTextToClipboard(snippetText); }}> Copy to Clipboard <FontAwesomeIcon icon={faCopy} /></a>
+                  </div>
+
+                  <div>
+                    <code ref={snippetTextElementRef}>{snippetText}</code>
+                  </div>
+                </div>
+              );
+            })
+          }
+        </div>
+      </li>
+    );
+  }
+}
+
+export default SnippetItem;

--- a/src/snippets/SnippetItem.jsx
+++ b/src/snippets/SnippetItem.jsx
@@ -127,7 +127,7 @@ export class SnippetItem extends React.Component {
     if (isCollapsed) {
       return (
         <li key={distId}>
-          <a className="selected-dataset" href="#" onClick={() => this.props.toggleCollapsed(distId)}>
+          <a className="selected-dataset" href="#" onClick={(e) => { this.props.toggleCollapsed(distId); e.preventDefault(); }}>
             <FontAwesomeIcon className="arrow-icon" icon={faChevronRight} /> &nbsp;
             {dist.title}
           </a>
@@ -137,7 +137,7 @@ export class SnippetItem extends React.Component {
 
     return (
       <li key={distId}>
-        <a className="selected-dataset" href="#" onClick={() => this.props.toggleCollapsed(distId)}>
+        <a className="selected-dataset" href="#" onClick={(e) => { this.props.toggleCollapsed(distId); e.preventDefault(); }}>
           <FontAwesomeIcon className="arrow-icon" icon={faChevronDown} /> &nbsp;
           {dist.title}
         </a>

--- a/src/snippets/SnippetItem.jsx
+++ b/src/snippets/SnippetItem.jsx
@@ -162,7 +162,7 @@ export class SnippetItem extends React.Component {
                 <div key={language}>
                   <div>
                     {language}
-                    <a href="#" className="float-right source" onClick={() => { selectElementText(snippetTextElementRef.current); copyTextToClipboard(snippetText); }}> Copy to Clipboard <FontAwesomeIcon icon={faCopy} /></a>
+                    <a href="#" className="float-right source" onClick={(e) => { selectElementText(snippetTextElementRef.current); copyTextToClipboard(snippetText); e.preventDefault(); }}> Copy to Clipboard <FontAwesomeIcon icon={faCopy} /></a>
                   </div>
 
                   <div>

--- a/src/snippets/actions.js
+++ b/src/snippets/actions.js
@@ -3,5 +3,5 @@ import { action } from '../utils';
 
 export const SNIPPET_SELECTION_ADD_DATASET = 'SNIPPET/SELECTION/ADD_DATASET';
 export const SNIPPET_SELECTION_DELETE_DATASET = 'SNIPPET/SELECTION/DELETE_DATASET';
-export const selectionAddDataset = action(SNIPPET_SELECTION_ADD_DATASET);
-export const selectionDeleteDataset = action(SNIPPET_SELECTION_DELETE_DATASET);
+export const selectionAddDistribution = action(SNIPPET_SELECTION_ADD_DATASET);
+export const selectionDeleteDistribution = action(SNIPPET_SELECTION_DELETE_DATASET);

--- a/src/snippets/actions.js
+++ b/src/snippets/actions.js
@@ -1,0 +1,7 @@
+
+import { action } from '../utils';
+
+export const SNIPPET_SELECTION_ADD_DATASET = 'SNIPPET/SELECTION/ADD_DATASET';
+export const SNIPPET_SELECTION_DELETE_DATASET = 'SNIPPET/SELECTION/DELETE_DATASET';
+export const selectionAddDataset = action(SNIPPET_SELECTION_ADD_DATASET);
+export const selectionDeleteDataset = action(SNIPPET_SELECTION_DELETE_DATASET);

--- a/src/snippets/reducers.js
+++ b/src/snippets/reducers.js
@@ -1,0 +1,39 @@
+import { combineReducers } from 'redux';
+import { Map } from 'immutable';
+import * as actions from './actions';
+
+/**
+ * Reducer for `selectedDatasets`
+ * @param {Map<string, object>} state
+ * @param {object} action
+ */
+function selectedDatasets(state = Map(), action) {
+  switch (action.type) {
+    case actions.SNIPPET_SELECTION_ADD_DATASET: {
+      /** Dataset to add */
+      const dataset = action.payload;
+      return state.set(dataset._id, dataset);
+    }
+
+    case actions.SNIPPET_SELECTION_DELETE_DATASET: {
+      /** Dataset ID to remove */
+      const datasetId = action.payload;
+      return state.remove(datasetId);
+    }
+
+    default:
+      return state;
+  }
+}
+
+// export reducer as default ot be combined at unknown key at root level
+const reducers = {
+  selectedDatasets,
+};
+
+export default combineReducers(reducers);
+
+// define selectors here as well, these should match the structure in
+// combined reducer.
+/** @param {typeof reducers} state */
+export const getSelectedDatasets = state => state.selectedDatasets;

--- a/src/snippets/reducers.js
+++ b/src/snippets/reducers.js
@@ -7,18 +7,18 @@ import * as actions from './actions';
  * @param {Map<string, object>} state
  * @param {object} action
  */
-function selectedDatasets(state = Map(), action) {
+function selectedDistributions(state = Map(), action) {
   switch (action.type) {
     case actions.SNIPPET_SELECTION_ADD_DATASET: {
-      /** Dataset to add */
-      const dataset = action.payload;
-      return state.set(dataset._id, dataset);
+      /** Distribution to add */
+      const dist = action.payload;
+      return state.set(dist.identifier, dist);
     }
 
     case actions.SNIPPET_SELECTION_DELETE_DATASET: {
-      /** Dataset ID to remove */
-      const datasetId = action.payload;
-      return state.remove(datasetId);
+      /** Distribution ID to remove */
+      const distId = action.payload;
+      return state.remove(distId);
     }
 
     default:
@@ -28,7 +28,7 @@ function selectedDatasets(state = Map(), action) {
 
 // export reducer as default ot be combined at unknown key at root level
 const reducers = {
-  selectedDatasets,
+  selectedDistributions,
 };
 
 export default combineReducers(reducers);
@@ -36,4 +36,4 @@ export default combineReducers(reducers);
 // define selectors here as well, these should match the structure in
 // combined reducer.
 /** @param {typeof reducers} state */
-export const getSelectedDatasets = state => state.selectedDatasets;
+export const getSelectedDistributions = state => state.selectedDistributions;


### PR DESCRIPTION
* Changed snippets to now store individual distributions (one of possibly many files per data set) rather than the previous behaviour of storing references to the whole data set
* The "cart" is now stored in the Redux store rather than in local storage so as to streamline state/store access and to prevent entries persisting unintentionally across sessions
* Some code has been reworked for minor improvements in clarity
  * Additional work for splitting components up to be discussed at a future time
* Implemented snippet clipboard copying functionality
* Currently hiding "Store in Drive" button which is currently not used as feature has not yet been fully defined