### PR TITLE
Snippet metadata and miscellaneous work for 2018w51

### DIFF
--- a/src/ExplorerController.jsx
+++ b/src/ExplorerController.jsx
@@ -313,8 +313,8 @@ export class ExplorerController extends React.Component {
   /**
    * Adds a given distribution to the selection set for snippets
    */
-  addDistToSelection = (dataset) => {
-    this.props.dispatch(snippetActions.selectionAddDistribution(dataset));
+  addDistToSelection = (distribution) => {
+    this.props.dispatch(snippetActions.selectionAddDistribution(distribution));
   }
 
   /**
@@ -615,13 +615,13 @@ export class ExplorerController extends React.Component {
           </Col>
           <Col lg="9" md="12">
             <div className="selected">
-              <h4>Datasets Selected: { this.props.selectedDistributions.size }</h4>
+              <h4>Datasets Selected: {this.props.selectedDistributions.size}</h4>
               <a href="https://support.ecocloud.org.au/support/solutions/articles/6000200678-code-snippets" target="_blank" rel="noopener noreferrer" className="help-link"><FontAwesomeIcon icon={faQuestionCircle} /> How Do I Use This Selection?</a>
-              <Link to="/snippets" params={{ selectedDistributions: this.state.selectedDistributions }} className="btn btn-primary float-right">View Snippets </Link>
+              <Link to="/snippets" className="btn btn-primary float-right">View Snippets </Link>
               <ul className="selected-datasets">
                 {
                   [...this.props.selectedDistributions.values()].map(dist => (
-                    <li key={dist.identifier}><a className="selected-dataset"> { dist.title } <FontAwesomeIcon onClick={() => this.deleteDistFromSelection(dist.identifier)} icon={faTimes} /></a></li>
+                    <li key={dist.identifier}><a className="selected-dataset"> {dist.title} <FontAwesomeIcon onClick={() => this.deleteDistFromSelection(dist.identifier)} icon={faTimes} /></a></li>
                   ))
                 }
               </ul>
@@ -630,8 +630,8 @@ export class ExplorerController extends React.Component {
               <div className="results-list">
                 <header>
                   <div className="pagination">
-                    <span className="pages">Page {this.state.page} / { Math.ceil(this.state.hits / this.state.perpage) }</span>
-                    { this.renderPageButtons() }
+                    <span className="pages">Page {this.state.page} / {Math.ceil(this.state.hits / this.state.perpage)}</span>
+                    {this.renderPageButtons()}
                   </div>
                 </header>
                 <ResultsList
@@ -644,8 +644,8 @@ export class ExplorerController extends React.Component {
 
                 <footer>
                   <div className="pagination">
-                    <span className="pages">Page {this.state.page} / { Math.ceil(this.state.hits / this.state.perpage) }</span>
-                    { this.renderPageButtons() }
+                    <span className="pages">Page {this.state.page} / {Math.ceil(this.state.hits / this.state.perpage)}</span>
+                    {this.renderPageButtons()}
                   </div>
                 </footer>
               </div>

--- a/src/SnippetsController.jsx
+++ b/src/SnippetsController.jsx
@@ -44,6 +44,14 @@ function renderSnippets(distributions, collapsedDataset, toggleCollapseDistribut
           <SnippetItem
             key={dist.identifier}
             distribution={dist}
+
+            // Note that these three `dist` properties are not included in
+            // the original distribution objects; they are added when the object
+            // is put into the store
+            publisher={dist.publisher}
+            contactPoint={dist.contactPoint}
+            landingPage={dist.landingPage}
+
             collapsed={collapsedDataset.has(dist.identifier)}
             toggleCollapsed={toggleCollapseDistribution}
           />
@@ -90,7 +98,7 @@ export class SnippetsController extends React.Component {
    *
    * @param {string} distId Distribution identifier
    */
-  toggleCollapseDistribution(distId) {
+  toggleCollapseDistribution = (distId) => {
     if (this.state.collapsedDataset.has(distId)) {
       // Distribution already exists in set, delete entry => "show distribution"
       this.setState(prevState => ({
@@ -129,12 +137,12 @@ export class SnippetsController extends React.Component {
         <hr />
         <Row className="snippets-body">
           <Col xs="12">
-            { distributionMap.size === 0
+            {distributionMap.size === 0
               ? renderNoSnippets()
               : renderSnippets(
                 distributionMap.valueSeq(),
                 this.state.collapsedDataset,
-                this.toggleCollapseDistribution.bind(this),
+                this.toggleCollapseDistribution,
               )
             }
           </Col>

--- a/src/compute/ComputeTableBasic.jsx
+++ b/src/compute/ComputeTableBasic.jsx
@@ -96,11 +96,6 @@ class ComputeTableBasic extends React.Component {
     dispatch: PropTypes.func.isRequired,
   }
 
-  componentWillMount() {
-    const { dispatch } = this.props;
-    // fetch profiles
-  }
-
   /**
    * Terminates user's JupyterHub server
    *

--- a/src/explorer/ResultsList.jsx
+++ b/src/explorer/ResultsList.jsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
-  Row, Col, Alert, UncontrolledTooltip,
+  Row, Col, Alert,
 } from 'reactstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faExternalLinkSquareAlt } from '@fortawesome/free-solid-svg-icons/faExternalLinkSquareAlt';
 import { formatDate } from '../utils';
+import ResultsListDistributionItem from './ResultsListDistributionItem';
 
-export default
-class ResultsList extends React.Component {
+export default class ResultsList extends React.Component {
   static propTypes = {
     data: PropTypes.arrayOf(PropTypes.any).isRequired,
     license: PropTypes.objectOf(PropTypes.any),
@@ -21,7 +21,10 @@ class ResultsList extends React.Component {
     license: null,
   }
 
-  getLicence(longName) {
+  /**
+   * @param {string} longName Full name of the license
+   */
+  getLicenceShortName = (longName) => {
     const { license } = this.props;
     const longKey = longName.trim().toLocaleLowerCase();
     if (license) {
@@ -40,50 +43,33 @@ class ResultsList extends React.Component {
    * Handler for adding/removing distributions through checkboxes
    *
    * @param {object} dist Distribution object
+   * @param {object} recordMetadata Record metadata (generally `_source`)
    * @param {boolean} checked Whether the distribution has been checked to be
    *        added to the selection list
    */
-  handleCheckboxChange(dist, checked) {
-    // TODO: Component needs to be split so the distribution ID doesn't need to
-    // be provided to the handler and instead should be read from the
-    // subcomponent's props
-
+  handleDistributionCheckboxChange = (dist, recordMetadata, checked) => {
     // If checked, add to selection, otherwise remove
-    if (checked === true) {
-      this.props.addDistToSelection(dist);
+    if (checked) {
+      // The distribution object saved as a merged object with additional
+      // properties from the record metadata
+      this.props.addDistToSelection({
+        ...dist,
+        publisher: recordMetadata.publisher && recordMetadata.publisher.name,
+        contactPoint: recordMetadata.contactPoint && recordMetadata.contactPoint.identifier,
+        landingPage: recordMetadata.landingPage,
+      });
     } else {
       this.props.deleteDistFromSelection(dist.identifier);
     }
   }
 
   renderResults() {
-    const { data } = this.props;
+    const { data, selectedDistributions } = this.props;
 
     if (data.length > 0) {
-      const results = data.map((record, ridx) => {
+      const results = data.map((record) => {
         const r = record._source;
-        let dists;
-        if (r.distributions && r.distributions.length > 0) {
-          dists = r.distributions.map((dist, didx) => {
-            const distSelectionId = `dist-select-${dist.identifier}`;
-            return (
-              <li key={dist.identifier}>
-                <label htmlFor={distSelectionId}>
-                  <input type="checkbox" id={distSelectionId} checked={this.props.selectedDistributions.has(dist.identifier)} onChange={e => this.handleCheckboxChange(dist, e.target.checked)} />
-                  <span className="title">{dist.title}</span>
-                </label>
-                <small className="licence-header"> Format </small>
-                <small className="format">{dist.format}</small>
-                <i className="licence-hover" id={`dist-${ridx}-${didx}`}> <small className="licence-header">  Licence </small>
-                  <small className="licence">{dist.license ? this.getLicence(dist.license.name) : 'unknown'}</small>
-                </i>
-                <UncontrolledTooltip placement="top" target={`dist-${ridx}-${didx}`}>
-                  {dist.license ? dist.license.name : 'None'}
-                </UncontrolledTooltip>
-              </li>
-            );
-          });
-        }
+
         return (
           <div className="result" key={record._id}>
             <Row>
@@ -133,12 +119,24 @@ class ResultsList extends React.Component {
                   r.catalog && r.catalog.length > 0
                   && <p><strong>Provider:</strong> {r.catalog}</p>
                 }
-                { dists
+                {
+                  (r.distributions && r.distributions.length > 0)
                   && (
                     <div className="distributions-container">
                       <strong>Data and Resources</strong>
                       <ul className="distributions">
-                        { dists }
+                        {r.distributions.map(distribution => (
+                          <ResultsListDistributionItem
+                            key={distribution.identifier}
+                            distribution={distribution}
+                            publisher={r.publisher && r.publisher.name}
+                            contactPoint={r.contactPoint && r.contactPoint.identifier}
+                            landingPage={r.landingPage}
+                            selectedDistributions={selectedDistributions}
+                            licenseShortNameFunc={this.getLicenceShortName}
+                            onCheckedChange={checked => this.handleDistributionCheckboxChange(distribution, r, checked)}
+                          />
+                        ))}
                       </ul>
                     </div>
                   )
@@ -167,7 +165,7 @@ class ResultsList extends React.Component {
   render() {
     return (
       <div className="results">
-        { this.renderResults() }
+        {this.renderResults()}
       </div>
     );
   }

--- a/src/explorer/ResultsList.jsx
+++ b/src/explorer/ResultsList.jsx
@@ -47,7 +47,7 @@ export default class ResultsList extends React.Component {
    * @param {boolean} checked Whether the distribution has been checked to be
    *        added to the selection list
    */
-  handleDistributionCheckboxChange = (dist, recordMetadata, checked) => {
+  onDistributionCheckedChange = (dist, recordMetadata, checked) => {
     // If checked, add to selection, otherwise remove
     if (checked) {
       // The distribution object saved as a merged object with additional
@@ -125,16 +125,18 @@ export default class ResultsList extends React.Component {
                     <div className="distributions-container">
                       <strong>Data and Resources</strong>
                       <ul className="distributions">
-                        {r.distributions.map(distribution => (
+                        {r.distributions.map(dist => (
                           <ResultsListDistributionItem
-                            key={distribution.identifier}
-                            distribution={distribution}
+                            key={dist.identifier}
+                            distribution={dist}
                             publisher={r.publisher && r.publisher.name}
                             contactPoint={r.contactPoint && r.contactPoint.identifier}
                             landingPage={r.landingPage}
                             selectedDistributions={selectedDistributions}
                             licenseShortNameFunc={this.getLicenceShortName}
-                            onCheckedChange={checked => this.handleDistributionCheckboxChange(distribution, r, checked)}
+                            onCheckedChange={
+                              checked => this.onDistributionCheckedChange(dist, r, checked)
+                            }
                           />
                         ))}
                       </ul>

--- a/src/explorer/ResultsListDistributionItem.jsx
+++ b/src/explorer/ResultsListDistributionItem.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Map } from 'immutable';
+import { UncontrolledTooltip } from 'reactstrap';
+
+export default class ResultsListDistributionItem extends React.PureComponent {
+  static propTypes = {
+    distribution: PropTypes.objectOf(PropTypes.any).isRequired,
+    selectedDistributions: PropTypes.objectOf(Map).isRequired,
+    licenseShortNameFunc: PropTypes.func.isRequired,
+    onCheckedChange: PropTypes.func,
+  }
+
+  static defaultProps = {
+    onCheckedChange: () => { },
+  }
+
+  render() {
+    const {
+      distribution: dist,
+      selectedDistributions,
+      licenseShortNameFunc,
+      onCheckedChange,
+    } = this.props;
+
+    /** @type {string} */
+    const distId = dist.identifier;
+    const checkboxId = `dist-select-${distId}`;
+    const licenseTooltipId = `dist-tooltip-${distId}`;
+
+    return (
+      <li>
+        <label htmlFor={checkboxId}>
+          <input type="checkbox" id={checkboxId} checked={selectedDistributions.has(distId)} onChange={e => onCheckedChange(e.target.checked)} />
+          <span className="title">{dist.title}</span>
+        </label>
+        <small className="licence-header"> Format </small>
+        <small className="format">{dist.format}</small>
+        <i className="licence-hover" id={licenseTooltipId}> <small className="licence-header">  Licence </small>
+          <small className="licence">{dist.license ? licenseShortNameFunc(dist.license.name) : 'unknown'}</small>
+        </i>
+        <UncontrolledTooltip placement="top" target={licenseTooltipId}>
+          {dist.license ? dist.license.name : 'None'}
+        </UncontrolledTooltip>
+      </li>
+    );
+  }
+}


### PR DESCRIPTION
* Implemented additional metadata in snippets (ausecocloud/ecocloud/issues/76)
* Reorganised state update for the `LaunchServer` component to move `setState()` out of `componentDidUpdate()` (also resolves lint errors in relation to this)
  * @gweis Please have a look at this and confirm if it now works the way you'd expect
* Minor tidy ups